### PR TITLE
CI: install required dependencies for building

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,15 +4,23 @@ on: [push, pull_request]
 jobs:
   test:
     name: cargo test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --quiet -y --no-install-recommends \
+          linux-libc-dev \
+          libclang-dev \
+          llvm
+
       - run: cargo test --all-features
 
   format:
     name: cargo format
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ This is a Rust reimplementation of hid-replay from
 
 # Installation
 
-`hid-replay` needs access to the `/dev/uhid` device and typically needs 
-to run as root. 
+`hid-replay` needs access to the `/dev/uhid` device and typically needs
+to run as root.
 
 The easiest is to install with cargo as root:
 
@@ -56,7 +56,7 @@ $ sudo hid-replay path/to/recording
 ### Allow access to the device to non-root users
 
 This is the least safe option as once read access is granted, any
-process can create virtual HID devices. This allows for malicious 
+process can create virtual HID devices. This allows for malicious
 interference with your running session.
 
 ```
@@ -64,7 +64,7 @@ $ cargo install hid-replay
 $ sudo chmod o+r /dev/uhid
 $ hid-replay path/to/recording
 ```
-It is recommended to remove these permissions once need for 
+It is recommended to remove these permissions once need for
 replaying is over:
 
 ```


### PR DESCRIPTION
Not 100% linux-libc-dev is really needed but in my 22.04 podman container here the /usr/include/linux/hid somes from 5.15.0-107.117 and that is missing kernel commit 5cc4cabe248f501373c (in v6.1 and later). That makes uhid-virt fail because some of the bindgen names are missing.