### PR TITLE
Skip pauses and print events in verbose mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -353,13 +353,29 @@ fn hid_replay() -> Result<()> {
                     std::thread::sleep(interval);
                 }
             }
-            print!("\r{1:0$}*{1:2$}", pos as usize, " ", 50 - pos as usize);
-            std::io::stdout().flush().unwrap();
-            uhid_device.write(&e.bytes)?;
-            pos += direction;
-            if pos % 49 == 0 {
-                direction *= -1;
+            if cli.verbose {
+                // Note: printing the event's original timestamp, not the current timestamp
+                // so it's easier to match the --verbose output with the recording.
+                println!(
+                    "\rE: {:06}.{:06} {} {}",
+                    e.usecs / 1000000,
+                    e.usecs % 1000000,
+                    e.bytes.len(),
+                    e.bytes
+                        .iter()
+                        .map(|b| format!("{:02x}", b))
+                        .collect::<Vec<String>>()
+                        .join(" ")
+                );
+            } else {
+                print!("\r{1:0$}*{1:2$}", pos as usize, " ", 50 - pos as usize);
+                pos += direction;
+                if pos % 49 == 0 {
+                    direction *= -1;
+                }
+                std::io::stdout().flush().unwrap();
             }
+            uhid_device.write(&e.bytes)?;
         }
         print!("\r{:50}\r", " ");
         std::io::stdout().flush().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,11 @@ struct Cli {
     #[arg(long, default_value_t = 0)]
     stop_time: u64,
 
+    /// Replace any pauses in the recording that
+    /// exceed N seconds with a 1s pause
+    #[arg(long)]
+    skip_pauses: Option<u64>,
+
     /// Path to the hid-recorder recording
     recording: PathBuf,
 }
@@ -329,18 +334,36 @@ fn hid_replay() -> Result<()> {
             break;
         }
         let start_time = Instant::now();
+        // If we skip over pauses, all events after pauses need to be offset
+        // by the pause.
+        let mut offset = Duration::from_secs(0);
         for e in &recording.events {
             let current_time = Instant::now();
             // actual time passed since we started
             let elapsed = current_time.duration_since(start_time);
             // what our recording said
-            let target_time = Duration::from_micros(e.usecs);
+            let target_time = Duration::from_micros(e.usecs) - offset;
             if target_time > elapsed {
-                let interval = target_time - elapsed;
+                let mut interval = target_time - elapsed;
+                match cli.skip_pauses {
+                    None => {}
+                    Some(skip) => {
+                        if interval > Duration::from_secs(skip) {
+                            let skip_time = Duration::from_secs(1);
+                            offset += interval - skip_time;
+                            let note = format!(
+                                "***** Skipping over pause of {}s *****",
+                                interval.as_secs()
+                            );
+                            print!("\r{:^50}", note);
+                            std::io::stdout().flush().unwrap();
+                            interval = skip_time;
+                        }
+                    }
+                }
                 if interval < Duration::from_secs(2) {
                     std::thread::sleep(interval);
                 } else {
-                    let mut interval = interval;
                     while interval > Duration::from_secs(1) {
                         let note = format!("***** Sleeping for {}s *****", interval.as_secs());
                         print!("\r{:^50}", note);


### PR DESCRIPTION
If run with `--verbose`, prind the HID events as we're sending them to the kernel.

And add a new argument `--skip-pauses` so we can skip over any pauses in the recording. It's quite common for users to provide recordings that have e.g. 20 or 30s pauses in them. Replaying them in real-time can be frustrating, editing the recording to change all subsequent timestamps equally so. And easier way is to just skip over the pauses (reducing them to 1s).